### PR TITLE
Chris' changes to add p4c-dpdk docker file and make targets to dash-pipeline

### DIFF
--- a/.github/workflows/dash-p4c-dpdk-docker.yml
+++ b/.github/workflows/dash-p4c-dpdk-docker.yml
@@ -1,0 +1,42 @@
+name: DASH-docker-p4c-dpdk-build-image
+
+on:
+  push:
+    branches: [ "**" ]
+    paths:
+      - '.github/workflows/dash-p4c-dpdk-docker.yml'
+      - 'dash-pipeline/dockerfiles/Dockerfile.p4c-dpdk'
+      - 'dash-pipeline/dockerfiles/DOCKER_P4C_DPDK_IMG.env'
+      - 'dash-pipeline/.dockerignore'
+      - 'dash-pipeline/dockerfiles/.dockerignore'
+  pull_request:
+    branches: [ "**" ]
+    paths:
+      - '.github/workflows/dash-p4c-dpdk-docker.yml'
+      - 'dash-pipeline/dockerfiles/Dockerfile.p4c-dpdk'
+      - 'dash-pipeline/dockerfiles/DOCKER_P4C_DPDK_IMG.env'
+      - 'dash-pipeline/.dockerignore'
+      - 'dash-pipeline/dockerfiles/.dockerignore'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build docker dash-p4c-dpdk image
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./dash-pipeline
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build dash-p4c-dpdk docker image
+      run: make docker-dash-p4c-dpdk
+
+    - uses: azure/docker-login@v1
+      if: ${{ github.event_name != 'pull_request' && github.repository == 'Azure/DASH' }}
+      with:
+        login-server: sonicdash.azurecr.io
+        username: ${{ secrets.DASH_ACR_USERNAME }}
+        password: ${{ secrets.DASH_ACR_PASSWORD }}
+    - name: Publish dash-p4c-dpdk docker image to ACR
+      run: make docker-publish-dash-p4c-dpdk
+      if: ${{ github.event_name != 'pull_request' && github.repository == 'Azure/DASH' }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 __pycache__/
 .pytest_cache/
 dash-pipeline/bmv2/dash_pipeline.bmv2/
+dash-pipeline/dpdk-pna/dash_pipeline.dpdk
 dash-pipeline/SAI/lib/
 dash-pipeline/SAI/rpc/

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -157,6 +157,7 @@ dockerized
 DoS
 DotNet
 downcasting
+dpdk
 DPDK
 DPU
 dpu
@@ -206,12 +207,14 @@ EPUs
 EPYC
 executables
 ExpressRoute
+extern
 failover
 failovers
 fakesai
 FastPath
 FEC
 ffe
+Fingerhut
 FINPackets
 fixup
 FNI
@@ -286,6 +289,7 @@ IxLoad
 ixload
 IxNetwork
 IxNetworkWeb
+jafingerhut
 Jinja
 jitter
 journaled
@@ -398,6 +402,7 @@ pluggable
 PLVision's
 pmon
 PNA
+pna
 png
 Policer
 policer
@@ -651,6 +656,7 @@ VxLan
 vxlan
 warmboots
 wflow
+WG
 WIP
 Wireshark
 wireshark

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -126,8 +126,14 @@ P4_DPDK_OUTDIR=dpdk-pna/dash_pipeline.dpdk
 # -DDPDK_PNA_SEND_TO_PORT_FIX_MERGED
 # -DDPDK_SUPPORTS_DIRECT_COUNTER_ON_WILDCARD_KEY_TABLE
 
+# [cs] If you do this, it complains it can't find "arch_specific.p4"
+#P4_MAIN_DPDK=dpdk-pna/dash_pipeline.p4
+
+# We want to compile from single code base:
+P4_MAIN_DPDK=$(P4_MAIN)
+
 p4c-dpdk-pna:
-	@echo "Compile P4 program $(P4_MAIN) for dpdk-pna ..."
+	@echo "Compile P4 program $(P4_MAIN_DPDK) for dpdk-pna ..."
 	mkdir -p $(P4_DPDK_OUTDIR) && \
 	chmod o+w $(P4_DPDK_OUTDIR) && \
 	docker run \
@@ -141,7 +147,7 @@ p4c-dpdk-pna:
 	$(DOCKER_P4C_DPDK_IMG)  \
 	p4c-dpdk -DDPDK_PNA -DPNA_CONNTRACK --dump $(P4_DPDK_OUTDIR) --pp $(P4_DPDK_OUTDIR)/dash_pipeline.pp.p4 \
 	-o $(P4_DPDK_OUTDIR)/dash_pipeline.spec --arch pna --bf-rt-schema $(P4_DPDK_OUTDIR)/dash_pipeline.p4.bfrt.json \
-	--p4runtime-files $(P4_DPDK_OUTDIR)/dash_pipeline.p4.p4info.txt $(P4_MAIN)
+	--p4runtime-files $(P4_DPDK_OUTDIR)/dash_pipeline.p4.p4info.txt $(P4_MAIN_DPDK)
 
 ######################################
 # DASH SAI HEADER & libsai.so TARGETS

--- a/dash-pipeline/Makefile
+++ b/dash-pipeline/Makefile
@@ -32,6 +32,10 @@ include dockerfiles/DOCKER_GRPC_IMG.env
 # include file defines DOCKER_P4C_BMV2_IMG
 include dockerfiles/DOCKER_P4C_BMV2_IMG.env
 
+# Slimmed-down version dpdk backend only
+# include file defines DOCKER_P4C_DPDK_IMG
+include dockerfiles/DOCKER_P4C_DPDK_IMG.env
+
 # Builds sai-P4rt clients to run inside bmv2 process
 # include file defines DOCKER_BMV2_BLDR_IMG_NAME and DOCKER_BMV2_BLDR_IMG_CTAG
 include dockerfiles/DOCKER_BMV2_BLDR_IMG.env
@@ -94,7 +98,7 @@ p4-clean:
 	-rm -rf $(P4_OUTDIR)
 # Compile P4 into bmv2 .json fle and P4info for SAI header autogeneration
 $(P4_ARTIFACTS): $(P4_SRC)
-	@echo "Compile P4 program $(P4_MAIN) ..."
+	@echo "Compile P4 program $(P4_MAIN) for bmv2 ..."
 	mkdir -p $(P4_OUTDIR) && \
 	chmod o+w $(P4_OUTDIR) && \
 	docker run \
@@ -109,6 +113,35 @@ $(P4_ARTIFACTS): $(P4_SRC)
 		-b bmv2 \
 		-o $(P4_OUTDIR) \
 	    --p4runtime-files $(P4_OUTDIR)/dash_pipeline_p4rt.json,$(P4_OUTDIR)/dash_pipeline_p4rt.txt
+
+# DPDK - experimental/WIP
+
+P4_DPDK_OUTDIR=dpdk-pna/dash_pipeline.dpdk
+
+# These command line options can be added if/when p4c-dpdk is enhanced
+# to support the code that is #ifdef'd out when these symbols are not
+# defined.  Search for these symbols in dash_pipeline.p4 for more
+# details.
+
+# -DDPDK_PNA_SEND_TO_PORT_FIX_MERGED
+# -DDPDK_SUPPORTS_DIRECT_COUNTER_ON_WILDCARD_KEY_TABLE
+
+p4c-dpdk-pna:
+	@echo "Compile P4 program $(P4_MAIN) for dpdk-pna ..."
+	mkdir -p $(P4_DPDK_OUTDIR) && \
+	chmod o+w $(P4_DPDK_OUTDIR) && \
+	docker run \
+	--rm \
+	--name dash-p4c-$(USER) \
+	-u $(DASH_USER) \
+	$(DOCKER_FLAGS) \
+	-v $(PWD)/bmv2:/bmv2 \
+	-v $(PWD)/dpdk-pna:/dpdk-pna \
+	-w / \
+	$(DOCKER_P4C_DPDK_IMG)  \
+	p4c-dpdk -DDPDK_PNA -DPNA_CONNTRACK --dump $(P4_DPDK_OUTDIR) --pp $(P4_DPDK_OUTDIR)/dash_pipeline.pp.p4 \
+	-o $(P4_DPDK_OUTDIR)/dash_pipeline.spec --arch pna --bf-rt-schema $(P4_DPDK_OUTDIR)/dash_pipeline.p4.bfrt.json \
+	--p4runtime-files $(P4_DPDK_OUTDIR)/dash_pipeline.p4.p4info.txt $(P4_MAIN)
 
 ######################################
 # DASH SAI HEADER & libsai.so TARGETS
@@ -449,16 +482,6 @@ run-saithrift-client-bash:
 
 ###############################
 
-# docker-dash-p4c:
-# 	docker build \
-# 		-f dockerfiles/Dockerfile.p4c-bmv2 \
-# 	    -t $(DOCKER_P4C_BMV2_IMG) \
-# 	    --build-arg user=$(USER) \
-# 	    --build-arg uid=$(shell id -u) \
-# 	    --build-arg guid=$(shell id -g) \
-# 	    --build-arg hostname=$(shell echo $$HOSTNAME) \
-# 	    --build-arg available_processors=$(shell nproc) \
-# 		dockerfiles
 
 DOCKER_P4C_BMV2_IMG_TAG = $(shell cat dockerfiles/Dockerfile.p4c-bmv2 | sha1sum | awk '{print substr($$1,0,11);}')
 DOCKER_P4C_BMV2_IMG = $(DOCKER_P4C_BMV2_IMG_NAME):$(DOCKER_P4C_BMV2_IMG_TAG)
@@ -486,6 +509,35 @@ docker-publish-dash-p4c:
 	docker push $(DOCKER_P4C_BMV2_IMG)
 	[ -n $(DOCKER_P4C_BMV2_IMG_CTAG) ] && \
 		docker push $(DOCKER_P4C_BMV2_IMG_NAME):$(DOCKER_P4C_BMV2_IMG_CTAG)
+
+###############################
+
+DOCKER_P4C_DPDK_IMG_TAG = $(shell cat dockerfiles/Dockerfile.p4c-dpdk | sha1sum | awk '{print substr($$1,0,11);}')
+DOCKER_P4C_DPDK_IMG = $(DOCKER_P4C_DPDK_IMG_NAME):$(DOCKER_P4C_DPDK_IMG_TAG)
+
+docker-dash-p4c-dpdk:
+	{ [ x$(ENABLE_DOCKER_PULL) == xy ] && docker pull $(DOCKER_P4C_DPDK_IMG); } || \
+	docker build \
+		-f dockerfiles/Dockerfile.p4c-dpdk \
+	    -t $(DOCKER_P4C_DPDK_IMG) \
+	    --build-arg user=$(DASH_USER) \
+	    --build-arg group=$(DASH_GROUP) \
+	    --build-arg uid=$(DASH_UID) \
+	    --build-arg guid=$(DASH_GUID) \
+	    --build-arg hostname=$(DASH_HOST) \
+	    --build-arg available_processors=$(shell nproc) \
+		dockerfiles
+	[ -n $(DOCKER_P4C_DPDK_IMG_CTAG) ] && \
+		docker tag $(DOCKER_P4C_DPDK_IMG) $(DOCKER_P4C_DPDK_IMG_NAME):$(DOCKER_P4C_DPDK_IMG_CTAG)
+
+docker-pull-dash-p4c-dpdk:
+	docker pull $(DOCKER_P4C_DPDK_IMG)
+
+docker-publish-dash-p4c-dpdk:
+	@echo "Publish $(DOCKER_P4C_DPDK_IMG) - requires credentials, can only do from DASH repo, not a fork"
+	docker push $(DOCKER_P4C_DPDK_IMG)
+	[ -n $(DOCKER_P4C_DPDK_IMG_CTAG) ] && \
+		docker push $(DOCKER_P4C_DPDK_IMG_NAME):$(DOCKER_P4C_DPDK_IMG_CTAG)
 
 ###############################
 

--- a/dash-pipeline/dockerfiles/DOCKER_P4C_DPDK_IMG.env
+++ b/dash-pipeline/dockerfiles/DOCKER_P4C_DPDK_IMG.env
@@ -1,0 +1,5 @@
+# Define docker image repo/name:tag
+# Changing this will cause build/publish to occur in CI actions
+export DASH_ACR_REGISTRY=sonicdash.azurecr.io
+export DOCKER_P4C_DPDK_IMG_NAME?=${DASH_ACR_REGISTRY}/dash-p4c-dpdk
+export DOCKER_P4C_DPDK_IMG_CTAG?=230130

--- a/dash-pipeline/dockerfiles/Dockerfile.p4c-dpdk
+++ b/dash-pipeline/dockerfiles/Dockerfile.p4c-dpdk
@@ -1,0 +1,61 @@
+# This Dockerfile builds an image used to compile P4 programs for the bmv2 backend only
+# It's based on public p4lang/p4c docker but strips out uneeded backends.
+# See https://docs.docker.com/develop/develop-images/multistage-build/
+FROM p4lang/p4c:latest as p4lang-p4c
+# :latest on 2023-01-30:
+#FROM p4lang/p4c@sha256:<TODO-need SHA> as p4lang-p4c
+LABEL maintainer="SONIC-DASH Community"
+LABEL description="DASH p4c-dpdk compiler, minimal"
+
+# Configure make to run as many parallel jobs as cores available
+ARG available_processors
+ARG MAKEFLAGS=-j$available_processors
+
+ARG CC=gcc
+ARG CXX=g++
+# Set TZ to avoid interactive installer
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+ENV GIT_SSL_NO_VERIFY=true
+
+# Just copy minimal p4c bins & libs for bm2 backends
+# ~632 MB vs. 971MB for unmodifed p4lang/p4c:stable
+FROM amd64/ubuntu:20.04
+# Need python for "p4c" wrapper &  gcc for the C preprocessor
+RUN apt update && apt install -y python3 gcc
+
+COPY --from=p4lang-p4c /usr/local/lib/* /usr/local/lib/
+
+COPY --from=p4lang-p4c \
+        /usr/lib/x86_64-linux-gnu/libboost_*so* \
+        /usr/lib/x86_64-linux-gnu/libgc*so* \
+        /usr/lib/x86_64-linux-gnu/libisl*so* \
+        /usr/lib/x86_64-linux-gnu/libmpc*so* \
+        /usr/lib/x86_64-linux-gnu/libmpfr*so* \
+        /usr/lib/x86_64-linux-gnu/
+
+COPY --from=p4lang-p4c /usr/lib/gcc/x86_64-linux-gnu /usr/lib/gcc/x86_64-linux-gnu/
+COPY --from=p4lang-p4c /usr/bin/cpp /usr/bin/
+COPY --from=p4lang-p4c /usr/local/share/p4c/ /usr/local/share/p4c/
+
+WORKDIR /usr/local/bin
+
+COPY --from=p4lang-p4c \
+        /usr/local/bin/p4c \
+        /usr/local/bin/p4c-dpdk \
+        /usr/local/bin/
+
+
+ARG user
+ARG uid
+ARG group
+ARG guid
+ARG hostname
+
+ENV BUILD_HOSTNAME $hostname
+ENV USER $user
+
+RUN groupadd -f -r -g $guid $group
+
+RUN useradd $user -l -u $uid -g $guid -d /var/$user -m -s /bin/bash
+CMD bash


### PR DESCRIPTION
This adds make targets to build a dash-p4c-dpdk docker image based on dockerhub p4lang/p4c:latest, and another to compile the dash P4 pipeline using this compiler.

Usage:
```
cd dash-pipeline
make docker-dash-p4c-dpdk    # one time only
make p4c-dpdk-pna            # compile, output goes to dpdk-pna/dash_pipeline.dpdk
```

Note, the goal is to compile from a single source of code. See macro `P4_MAIN_DPDK` in `dash-pipeline/Makefile`. I've left it so you can play with this macro to compile the dpdk-specific code under `dpdk-pna` or the original code under `bmv2`. The code under `dpdk-pna` fails right away because it tries to `include "arch_specific.p4"` which isn't found.

A next step would be to produce a single P4 source and pass in a macro to the p4c preprocessor from the make target `docker-dash-p4c-dpdk`